### PR TITLE
made pig wool rarer

### DIFF
--- a/src/main/java/mokiyoki/enhancedanimals/entity/genetics/PigGeneticsInitialiser.java
+++ b/src/main/java/mokiyoki/enhancedanimals/entity/genetics/PigGeneticsInitialiser.java
@@ -298,13 +298,11 @@ public class PigGeneticsInitialiser extends AbstractGeneticsInitialiser {
         //wooly [ thicker hair, wildtype, curly wool ]
         if (ThreadLocalRandom.current().nextInt(100) > WTC) {
             autosomalGenes[38] = (ThreadLocalRandom.current().nextInt(3) + 1);
-
         } else {
             autosomalGenes[38] = (2);
         }
         if (ThreadLocalRandom.current().nextInt(100) > WTC) {
-            autosomalGenes[39] = (ThreadLocalRandom.current().nextInt(3) + 1);
-
+            autosomalGenes[39] = (ThreadLocalRandom.current().nextInt(2) + 1);
         } else {
             autosomalGenes[39] = (2);
         }


### PR DESCRIPTION
Disabled the ability for two copies of curly wool to spawn in the wild. I was noticing a disproportionately high number of wooly pigs since it's a dominant gene, which seemed excessive for such a rare mutation