### PR TITLE
1.18.x Axolotl Eye Color Fixes

### DIFF
--- a/src/main/java/mokiyoki/enhancedanimals/entity/EnhancedAxolotl.java
+++ b/src/main/java/mokiyoki/enhancedanimals/entity/EnhancedAxolotl.java
@@ -652,6 +652,54 @@ public class EnhancedAxolotl extends EnhancedAnimalAbstract implements Bucketabl
     }
 
     @OnlyIn(Dist.CLIENT)
+    private float[] calculateEyeColor(int[] gene, int eyeType) {
+        //NormalEyes
+        float[] eyeHSB = {0.75F, 0.5F, 0.25F};
+
+        switch (eyeType) {
+            case 2 -> {
+                //DarkEyes
+                eyeHSB = Colouration.mixAxolotlHue((float) (gene[22]-1) / 255, (float) (gene[23]-1) / 255);
+                eyeHSB[2] *= 0.5F;
+            }
+            case 3 -> {
+                //PigmentedEyes
+                eyeHSB = Colouration.mixAxolotlHue((float) (gene[22]-1) / 255, (float) (gene[23]-1) / 255);
+            }
+            case 4 -> {
+                //LightEyes
+                eyeHSB = Colouration.mixAxolotlHue((float) (gene[22]-1) / 255, (float) (gene[23]-1) / 255);
+                eyeHSB[2] = 1.0F;
+            }
+            case 5 -> {
+                //PastelEyes
+                eyeHSB = Colouration.mixAxolotlHue((float) (gene[22]-1) / 255, (float) (gene[23]-1) / 255);
+                eyeHSB[1] *= 0.5F;
+                eyeHSB[2] = 1.0F;
+            }
+            default -> {
+                //NormalEyes
+                if (gene[0] == 2 && gene[1] == 2) {
+                    //Albino
+                    if (gene[2] == 2 && gene[3] == 2) {
+                        //Axanthic Albino
+                        eyeHSB[0] = 0.95F;
+                        eyeHSB[2] = 0.8F;
+                    } else {
+                        eyeHSB[0] = 0.09F;
+                        eyeHSB[1] = 0.75F;
+                        eyeHSB[2] = 0.8F;
+                    }
+                }
+            }
+
+
+        }
+        return eyeHSB;
+    }
+
+
+    @OnlyIn(Dist.CLIENT)
     public Colouration getRgb() {
         this.colouration = super.getRgb();
         Genes genes = getGenes();
@@ -660,10 +708,11 @@ public class EnhancedAxolotl extends EnhancedAnimalAbstract implements Bucketabl
                 int[] gene = genes.getAutosomalGenes();
 
                 if (gene[10] != 1 || gene[11] != 1) {
-                    this.colouration.setDyeColour(Colouration.mixAxolotlHue((float) (gene[24]-1) / 255, (float) (gene[25]-1) / 255));
+                    float[] axolotlHSB = Colouration.mixAxolotlHue((float) (gene[24]-1) / 255, (float) (gene[25]-1) / 255);
+                    this.colouration.setDyeColour(Colouration.HSBtoARGB(axolotlHSB[0], axolotlHSB[1], axolotlHSB[2]));
                 }
 
-                float eyeHue = 0.75F;
+                /*float eyeHue = 0.75F;
                 float eyeSaturation = 0.5F;
                 float eyeBrightness = 0.25F;
 
@@ -739,10 +788,12 @@ public class EnhancedAxolotl extends EnhancedAnimalAbstract implements Bucketabl
                             eyeBrightness = 0.75F;
                         }
                     }
-                }
+                }*/
 
-                this.colouration.setLeftEyeColour(Colouration.HSBtoARGB(eyeHue, eyeSaturation, eyeBrightness));
-                this.colouration.setRightEyeColour(Colouration.HSBtoARGB(eyeHue, eyeSaturation, eyeBrightness));
+                int eyeColor = Colouration.getAxolotlEyes(calculateEyeColor(gene, gene[20]), calculateEyeColor(gene, gene[21]));
+
+                this.colouration.setLeftEyeColour(eyeColor);
+                this.colouration.setRightEyeColour(eyeColor);
             }
         }
 

--- a/src/main/java/mokiyoki/enhancedanimals/entity/EnhancedAxolotl.java
+++ b/src/main/java/mokiyoki/enhancedanimals/entity/EnhancedAxolotl.java
@@ -677,6 +677,10 @@ public class EnhancedAxolotl extends EnhancedAnimalAbstract implements Bucketabl
                 eyeHSB[1] *= 0.5F;
                 eyeHSB[2] = 1.0F;
             }
+            case 6 -> {
+                //GlowEyes
+                eyeHSB = Colouration.mixAxolotlHue((float) (gene[22]-1) / 255, (float) (gene[23]-1) / 255);
+            }
             default -> {
                 //NormalEyes
                 if (gene[0] == 2 && gene[1] == 2) {

--- a/src/main/java/mokiyoki/enhancedanimals/entity/genetics/AxolotlGeneticsInitialiser.java
+++ b/src/main/java/mokiyoki/enhancedanimals/entity/genetics/AxolotlGeneticsInitialiser.java
@@ -124,7 +124,7 @@ public class AxolotlGeneticsInitialiser extends AbstractGeneticsInitialiser {
         autosomalGenes[19] = getChance() ? (ThreadLocalRandom.current().nextInt(2)+2) : 1;
 
         /**
-         *      [20,21] - ColouredEyes - DarkEyes >< PigmentedEyes >< LightEyes >< PastelEyes >< GlowEyes >< NormalEyes
+         *      [20,21] - ColouredEyes - NormalEyes >< DarkEyes >< PigmentedEyes >< LightEyes >< PastelEyes >< GlowEyes
          */
         autosomalGenes[20] = getChance() ? (ThreadLocalRandom.current().nextInt(5)+2) : 1;
         autosomalGenes[21] = getChance() ? (ThreadLocalRandom.current().nextInt(5)+2) : 1;

--- a/src/main/java/mokiyoki/enhancedanimals/entity/util/Colouration.java
+++ b/src/main/java/mokiyoki/enhancedanimals/entity/util/Colouration.java
@@ -154,7 +154,7 @@ public class Colouration {
         return colour1;
     }
 
-    public static int mixAxolotlHue(float hue1, float hue2) {
+    public static float[] mixAxolotlHue(float hue1, float hue2) {
 //        int[] color1 = getRGBFromHSB(hue1, 0.8F, 0.6F);
 //        int[] color2 = getRGBFromHSB(hue2, 0.8F, 0.6F);
 
@@ -172,10 +172,19 @@ public class Colouration {
             brightness = brightness + (((degreesDif-0.3333F)/0.1667F)*0.35F);
         }
 
-        int[] color = getRGBFromHSB(hue, saturation, brightness);
-
-        return 128 << 24 | (Math.min(color[0], 255)) << 16 | (Math.min(color[1], 255)) << 8 | (Math.min(color[2], 255));
+        return new float[]{hue, saturation, brightness};
     }
+
+    public static int getAxolotlEyes(float[] hsb1, float[] hsb2) {
+        int[] rgb1 = getRGBFromHSB(hsb1[0], hsb1[1], hsb1[2]);
+        int[] rgb2 = getRGBFromHSB(hsb2[0], hsb2[1], hsb2[2]);
+        int r = (rgb1[0] + rgb2[0])/2;
+        int g = (rgb1[1] + rgb2[1])/2;
+        int b = (rgb1[2] + rgb2[2])/2;
+
+        return 128 << 24 | (Math.min(r, 255)) << 16 | (Math.min(g, 255)) << 8 | (Math.min(b, 255));
+    }
+
 
     public static float[] getAxolotlLightEyes(float hue1, float hue2) {
         int[] color1 = getRGBFromHSB(hue1, 0.8F, 0.6F);
@@ -243,6 +252,7 @@ public class Colouration {
 
         return a << 24 | rgb[2] << 16 | rgb[1] << 8 | rgb[0];
     }
+
 
     public static float[] getHSBFromABGR(int colourABGR) {
         int colour[] = getRGBFromABGR(colourABGR);


### PR DESCRIPTION
Moved the axolotl eye color computation to a separate method that now uses the same code for both alleles. 
Fixes an issue that causes certain eye colors to be the complete opposite of their intended value by using the same code for eye colors as for body colors.
This also fixes a number of other eye color related bugs that are highly inconsistent and difficult to document, including sometimes-inconsistent behavior when the 20/21 alleles are swapped.