### PR TITLE
fixed longbody and longtail

### DIFF
--- a/src/main/java/mokiyoki/enhancedanimals/entity/genetics/AxolotlGeneticsInitialiser.java
+++ b/src/main/java/mokiyoki/enhancedanimals/entity/genetics/AxolotlGeneticsInitialiser.java
@@ -142,7 +142,7 @@ public class AxolotlGeneticsInitialiser extends AbstractGeneticsInitialiser {
         autosomalGenes[25] = ThreadLocalRandom.current().nextInt(255)+1;
 
         /**
-         *      [26,27] - LongTail
+         *      [26,27] - LongTail (Normal >< Long)
          */
         autosomalGenes[26] = getChance() ? 2 : 1;
         autosomalGenes[27] = getChance() ? 2 : 1;
@@ -160,7 +160,7 @@ public class AxolotlGeneticsInitialiser extends AbstractGeneticsInitialiser {
         autosomalGenes[31] = ThreadLocalRandom.current().nextInt(10)+1;
 
         /**
-         *      [32,33] - Long
+         *      [32,33] - Long - (Normal > long)
          */
         autosomalGenes[32] = getChance() ? 2 : 1;
         autosomalGenes[33] = getChance() ? 2 : 1;

--- a/src/main/java/mokiyoki/enhancedanimals/model/ModelEnhancedAxolotl.java
+++ b/src/main/java/mokiyoki/enhancedanimals/model/ModelEnhancedAxolotl.java
@@ -153,10 +153,10 @@ public class ModelEnhancedAxolotl<T extends EnhancedAxolotl> extends EnhancedAni
         bBody.addOrReplaceChild("bodyFinLong", CubeListBuilder.create()
                         .mirror(true)
                         .texOffs(26, 9)
-                        .addBox(0.01F, 0.0F, -5.0F, 0.0F, 11.0F, 5.0F)
+                        .addBox(0.01F, -2.0F, -5.0F, 0.0F, 11.0F, 5.0F)
                         .mirror(false)
                         .texOffs(26, 36)
-                        .addBox(-0.01F, 0.0F, -5.0F, 0.0F, 11.0F, 5.0F),
+                        .addBox(-0.01F, -2.0F, -5.0F, 0.0F, 11.0F, 5.0F),
                 PartPose.offsetAndRotation(0.0F, 2.0F, 10.0F, -Mth.HALF_PI, 0.0F, 0.0F)
         );
 
@@ -312,6 +312,12 @@ public class ModelEnhancedAxolotl<T extends EnhancedAxolotl> extends EnhancedAni
                 part.show(false);
             }
 
+            this.tail12.modelPart.visible = false;
+            this.tail13.modelPart.visible = false;
+            this.tail14.modelPart.visible = false;
+            this.tail15.modelPart.visible = false;
+            this.tail16.modelPart.visible = false;
+
             if (axolotl.isLong) {
                 this.head.modelPart.visible = false;
                 this.body.modelPart.visible = false;
@@ -332,10 +338,9 @@ public class ModelEnhancedAxolotl<T extends EnhancedAxolotl> extends EnhancedAni
                 this.bodyLong.modelPart.visible = false;
                 this.bodyFinLong.modelPart.visible = false;
                 switch (axolotl.tailLength) {
-                    case EXTRALONG -> this.tail14.show(true);
-                    case LONG -> this.tail13.show(true);
-                    case NORMAL -> this.tail12.show(true);
-                    default -> this.tail12.show(true);
+                    case EXTRALONG -> this.tail14.modelPart.visible = true;
+                    case LONG -> this.tail13.modelPart.visible = true;
+                    default -> this.tail12.modelPart.visible = true;
                 }
             }
 
@@ -420,6 +425,7 @@ public class ModelEnhancedAxolotl<T extends EnhancedAxolotl> extends EnhancedAni
         map.put("top_gills", this.getRotationVector(this.theGillsTop));
         map.put("left_gills", this.getRotationVector(this.theGillsLeft));
         map.put("right_gills", this.getRotationVector(this.theGillsRight));
+        map.put("bTailPos", this.getPosVector(this.theTail));
         map.put("bTail", this.getRotationVector(this.theTail));
         map.put("backLegs", new Vector3f(0.0F, 0.0F, this.theLegBackLeft.getZ()));
     }
@@ -430,6 +436,7 @@ public class ModelEnhancedAxolotl<T extends EnhancedAxolotl> extends EnhancedAni
             this.theAxolotl.setRotation(headPitch * -Mth.DEG_TO_RAD, netHeadYaw * Mth.DEG_TO_RAD, 0.0F);
             this.theAxolotl.setPos(0.0F, 20.0F, 4.0F);
             this.theHead.setPos(0.0F, 0.0F, 0.0F);
+            this.theTail.setZ(axolotl.isLong ? 12.0F : 10.0F);
             this.theTail.setRotation(0.0F, 0.0F, 0.0F);
             this.theLegBackLeft.setZ(axolotl.isLong ? 3.0F : -1.0F);
             this.theLegBackRight.setZ(axolotl.isLong ? 3.0F : -1.0F);
@@ -445,6 +452,7 @@ public class ModelEnhancedAxolotl<T extends EnhancedAxolotl> extends EnhancedAni
             this.setRotationFromVector(this.theGillsTop, map.get("top_gills"));
             this.setRotationFromVector(this.theGillsLeft, map.get("left_gills"));
             this.setRotationFromVector(this.theGillsRight, map.get("right_gills"));
+            this.setOffsetFromVector(this.theTail, map.get("bTailPos"));
             this.setRotationFromVector(this.theTail, map.get("bTail"));
             this.theLegBackLeft.setZ(map.get("backLegs").z());
             this.theLegBackRight.setZ(map.get("backLegs").z());

--- a/src/main/java/mokiyoki/enhancedanimals/model/modeldata/AxolotlPhenotype.java
+++ b/src/main/java/mokiyoki/enhancedanimals/model/modeldata/AxolotlPhenotype.java
@@ -11,12 +11,14 @@ public class AxolotlPhenotype implements Phenotype {
 
     public AxolotlPhenotype(Genes genes) {
         int[] gene = genes.getAutosomalGenes();
-        this.isLong = gene[32] == 2 && gene[33] == 2;
+        this.isLong = gene[32] == 2 && gene[33] == 2; //Long Body
 
-        if (gene[26] == gene[27]) {
-            this.tailLength = gene[32] == 1 ? AxolotlTailLength.NORMAL : AxolotlTailLength.EXTRALONG;
-        } else {
-            this.tailLength = AxolotlTailLength.LONG;
+        if (gene[26] == 2 || gene[27] == 2) {
+            //Long Tail
+            this.tailLength = gene[26] == gene[27] ? AxolotlTailLength.EXTRALONG : AxolotlTailLength.LONG;
+        }
+        else {
+            this.tailLength = AxolotlTailLength.NORMAL;
         }
 
         this.glowingBody = genes.has(10, 3) && !genes.has(10, 2);


### PR DESCRIPTION
- tail length on longbody axolotls is now offset to properly match that of its short bodied counterparts 
- back fin on longbody axolotls now has a pixel gap behind the head, like the short bodied ones 
- longtail gene is now incomplete dominant as intended rather than only working in the het form
- also added comments to the genetics initialiser explaining the inheritance of both genes