### PR TITLE
fixed bug where nonagouti/swallowbelly produced brown color

### DIFF
--- a/src/main/java/mokiyoki/enhancedanimals/entity/EnhancedPig.java
+++ b/src/main/java/mokiyoki/enhancedanimals/entity/EnhancedPig.java
@@ -885,7 +885,7 @@ public class EnhancedPig extends EnhancedAnimalRideableAbstract {
             boolean tusks = false;
             boolean agouti = true;
             boolean agoutiBlack = false;
-            boolean wideband = false;
+            boolean wideband = gene[164] == 2 && gene[165] == 2;
             boolean brindle = false;
 
 
@@ -909,13 +909,11 @@ public class EnhancedPig extends EnhancedAnimalRideableAbstract {
                 agoutiBlack = true;
             }
 
-            if (gene[2] == 3 && gene[3] == 3) {
+            if ( (gene[2] == 3 || gene[3] == 3) && (gene[2] == gene[3] || gene[2] == 4 || gene[3] == 4) ) {
+                //Either nonagouti or het nonagouti/het swallowbelly, since nonagouti is more dominant
                 agouti = false;
             }
 
-            if (gene[164] == 2 && gene[165] == 2) {
-                wideband = true;
-            }
 
             if (agouti) {
                 if (gene[2] == 2 || gene[3] == 2) {


### PR DESCRIPTION
Only real change is that I added a check for heterozygosity before agouti color assignment. 

I also moved the wideband assignment to the declaration since there was really no reason for a whole if statement to assign a single boolean.