### PR TITLE
fixed min size pea and walnut combs defaulting to large

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'org.spongepowered.mixin'
 
-version = '0_8_59'
+version = '0_8_60'
 group = 'com.mokiyoki.enhancedanimals' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'GeneticAnimals'
 

--- a/src/main/java/mokiyoki/enhancedanimals/model/ModelEnhancedChicken.java
+++ b/src/main/java/mokiyoki/enhancedanimals/model/ModelEnhancedChicken.java
@@ -1571,6 +1571,7 @@ public class ModelEnhancedChicken<T extends EnhancedChicken> extends EnhancedAni
                         }
                     } else if (chicken.comb == Comb.PEA || (chicken.comb == Comb.SINGLE && chicken.crestType != Crested.NONE)) {
                         switch (chicken.combSize) {
+                            case 0:
                             case 1:
                             case 2:
                                 combPeaS.show();
@@ -1588,6 +1589,7 @@ public class ModelEnhancedChicken<T extends EnhancedChicken> extends EnhancedAni
                         }
                     } else if (chicken.comb == Comb.WALNUT || ((chicken.comb == Comb.ROSE_ONE || chicken.comb == Comb.ROSE_TWO) && chicken.crestType != Crested.NONE)) {
                         switch (chicken.combSize) {
+                            case 0:
                             case 1:
                             case 2:
                                 combWalnutS.show();

--- a/src/main/java/mokiyoki/enhancedanimals/model/ModelEnhancedChicken.java
+++ b/src/main/java/mokiyoki/enhancedanimals/model/ModelEnhancedChicken.java
@@ -1571,36 +1571,26 @@ public class ModelEnhancedChicken<T extends EnhancedChicken> extends EnhancedAni
                         }
                     } else if (chicken.comb == Comb.PEA || (chicken.comb == Comb.SINGLE && chicken.crestType != Crested.NONE)) {
                         switch (chicken.combSize) {
-                            case 0:
-                            case 1:
-                            case 2:
+                            case 0 -> {}
+                            case 1, 2 -> {
                                 combPeaS.show();
                                 combRootPeaS.show();
-                                break;
-                            case 3:
+                            }
+                            case 3 -> {
                                 combPeaM.show();
                                 combRootPeaM.show();
-                                break;
-                            case 4:
-                            default:
+                            }
+                            default -> {
                                 combPeaL.show();
                                 combRootPeaL.show();
-                                break;
+                            }
                         }
                     } else if (chicken.comb == Comb.WALNUT || ((chicken.comb == Comb.ROSE_ONE || chicken.comb == Comb.ROSE_TWO) && chicken.crestType != Crested.NONE)) {
                         switch (chicken.combSize) {
-                            case 0:
-                            case 1:
-                            case 2:
-                                combWalnutS.show();
-                                break;
-                            case 3:
-                                combWalnutM.show();
-                                break;
-                            case 4:
-                            default:
-                                combWalnutL.show();
-                                break;
+                            case 0 -> {}
+                            case 1, 2 -> combWalnutS.show();
+                            case 3 -> combWalnutM.show();
+                            default -> combWalnutL.show();
                         }
                     } else if (chicken.comb == Comb.V) {
                         combV.show();

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -5,7 +5,7 @@ license="All rights reserved"
 
 [[mods]]
 modId="eanimod"
-version="0.8.59"
+version="0.8.60"
 displayName="Genetic Animals"
 logoFile="icon.png"
 authors="Moki, BeardedDev, Nicole, Mika, Navia"

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -3,7 +3,7 @@
     "modid": "eanimod",
     "name": "Genetic Animals",
     "description": "Add real-to-life animal genetics, improved animal behaviour and content adding mod.",
-    "version": "0.8.59",
+    "version": "0.8.60",
     "mcversion": "1.18.2",
     "url": "https://github.com/SaemonMoki/ExtendedAnimals/issues",
     "updateUrl": "",


### PR DESCRIPTION
both were caused by lack of case for 0 and default for the switch being set to the large model