### PR TITLE
undid rgb swapping on axolotls because it was correct before

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'org.spongepowered.mixin'
 
-version = '0_8_59'
+version = '0_8_60'
 group = 'com.mokiyoki.enhancedanimals' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'GeneticAnimals'
 

--- a/src/main/java/mokiyoki/enhancedanimals/entity/EnhancedAxolotl.java
+++ b/src/main/java/mokiyoki/enhancedanimals/entity/EnhancedAxolotl.java
@@ -721,86 +721,8 @@ public class EnhancedAxolotl extends EnhancedAnimalAbstract implements Bucketabl
 
                 if (gene[10] != 1 || gene[11] != 1) {
                     float[] axolotlHSB = Colouration.mixAxolotlHue((float) (gene[24]-1) / 255, (float) (gene[25]-1) / 255);
-                    this.colouration.setDyeColour(Colouration.HSBtoABGR(axolotlHSB[0], axolotlHSB[1], axolotlHSB[2]));
+                    this.colouration.setDyeColour(Colouration.HSBtoARGB(axolotlHSB[0], axolotlHSB[1], axolotlHSB[2]));
                 }
-
-                /*float eyeHue = 0.75F;
-                float eyeSaturation = 0.5F;
-                float eyeBrightness = 0.25F;
-
-                if (gene[20] == 1 && gene[21] == 1) {
-                    if (gene[0] == 2 && gene[1] == 2) {
-                        if (gene[2] == 2 && gene[3] == 2) {
-                            eyeHue = 0.95F;
-                            eyeBrightness = 0.8F;
-                        } else {
-                            eyeHue = 0.09F;
-                            eyeSaturation = 0.75F;
-                            eyeBrightness = 0.8F;
-                        }
-                    }
-                } else {
-                    if (gene[20] == 4 || gene[21] == 4) {
-                        int genenum = gene[20] == 4 ? 21 : 20;
-                        //light eyes
-                        float[] lightEyes = Colouration.getAxolotlLightEyes((float) (gene[22]-1) / 255, (float) (gene[23]-1) / 255);
-
-                        eyeHue = lightEyes[0];
-
-                        if (gene[genenum] == 2) {
-                            //dark eyes
-                            eyeSaturation = (lightEyes[1] + 1.0F) * 0.5F;
-                            eyeBrightness = lightEyes[2] * 0.5F;
-                        } else if (gene[genenum] == 3) {
-                            //pigmented eyes
-                            eyeSaturation = (lightEyes[1] + 1.0F) * 0.5F;
-                            eyeBrightness = (lightEyes[2] + 0.75F) * 0.5F;
-                        } else if (gene[genenum] == 5) {
-                            //light-pastel eyes
-                            eyeSaturation = (lightEyes[1] + 0.5F) * 0.5F;
-                            eyeBrightness = (lightEyes[1] + 0.75F) * 0.5F;
-                        } else {
-                            //light-glow eyes
-                            //light eyes
-                            eyeSaturation = lightEyes[1];
-                            eyeBrightness = lightEyes[2];
-                        }
-                    } else {
-                        eyeHue = Colouration.mixHueComponent((float) (gene[22]-1) / 255, (float) (gene[23]-1) / 255, 0.5F);
-
-                        if (gene[20] == 2) {
-                            //dark eyes
-                            if (gene[21] == 3) {
-                                //dark-pigmented eyes
-                                eyeSaturation = 1.0F;
-                                eyeBrightness = 0.5F;
-                            } else if (gene[21] == 5) {
-                                //dark-pastel eyes
-                                eyeBrightness = 0.4F;
-                            } else {
-                                //dark-glow eyes
-                                //dark eyes
-                                eyeSaturation = 1.0F;
-                            }
-                        } else if (gene[20] == 3 || gene[20] == 6) {
-                            //glow eyes
-                            //pigmented eyes
-                            if (gene[21] == 5) {
-                                //pigmented-pastel eyes
-                                eyeSaturation = 0.75F;
-                                eyeBrightness = 0.75F;
-                            } else {
-                                //pigmented-glow eyes
-                                //pigmented eyes
-                                eyeSaturation = 1.0F;
-                                eyeBrightness = 0.75F;
-                            }
-                        } else {
-                            //pastel eyes
-                            eyeBrightness = 0.75F;
-                        }
-                    }
-                }*/
 
                 int eyeColor = Colouration.getAxolotlEyes(calculateEyeColor(gene, gene[20]), calculateEyeColor(gene, gene[21]));
 

--- a/src/main/java/mokiyoki/enhancedanimals/entity/util/Colouration.java
+++ b/src/main/java/mokiyoki/enhancedanimals/entity/util/Colouration.java
@@ -182,7 +182,7 @@ public class Colouration {
         int g = (rgb1[1] + rgb2[1])/2;
         int r = (rgb1[0] + rgb2[0])/2;
 
-        return 128 << 24 | (Math.min(b, 255)) << 16 | (Math.min(g, 255)) << 8 | (Math.min(r, 255));
+        return 128 << 24 | (Math.min(r, 255)) << 16 | (Math.min(g, 255)) << 8 | (Math.min(b, 255));
     }
 
 

--- a/src/main/java/mokiyoki/enhancedanimals/util/Reference.java
+++ b/src/main/java/mokiyoki/enhancedanimals/util/Reference.java
@@ -7,7 +7,7 @@ public class Reference {
 
     public static final String MODID = "eanimod";
     public static final String NAME = "Genetic Animals Mod";
-    public static final String VERSION = "0.8.59";
+    public static final String VERSION = "0.8.60";
     public static final String ACCEPTED_VERSIONS = "[1.18.2]";
     public static final String CLIENT_PROXY_CLASS = "mokiyoki.enhancedanimals.proxy.ClientProxy";
     public static final String SERVER_PROXY_CLASS = "mokiyoki.enhancedanimals.proxy.ServerProxy";

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -5,7 +5,7 @@ license="All rights reserved"
 
 [[mods]]
 modId="eanimod"
-version="0.8.59"
+version="0.8.60"
 displayName="Genetic Animals"
 logoFile="icon.png"
 authors="Moki, BeardedDev, Nicole, Mika, Navia"

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -3,7 +3,7 @@
     "modid": "eanimod",
     "name": "Genetic Animals",
     "description": "Add real-to-life animal genetics, improved animal behaviour and content adding mod.",
-    "version": "0.8.59",
+    "version": "0.8.60",
     "mcversion": "1.18.2",
     "url": "https://github.com/SaemonMoki/ExtendedAnimals/issues",
     "updateUrl": "",


### PR DESCRIPTION
Basically undid PR #183 because it ""fixed"" a nonexistent bug (that was actually just the correction of a previous bug) and created a whole new problem. Oops. Have tested that it's working correctly now.